### PR TITLE
testExtent added

### DIFF
--- a/src/Discord-Core-Tests.package/DSEmbedImageTest.class/instance/testExtent.st
+++ b/src/Discord-Core-Tests.package/DSEmbedImageTest.class/instance/testExtent.st
@@ -1,0 +1,6 @@
+tests
+testExtent
+	object := self newObjectToTest.
+	object width: 41.
+	object height: 42.
+	self assert: object extent equals: 41 @ 42


### PR DESCRIPTION
I submit this pull request to suggest a test method `DSEmbedImageTest >> testExtent`.

We noticed that the methods #extent is never executed by any of the tests in DSEmbedImageTest. Yet, this is an important hook method in the class hierarchy so it is best to have a unit test for this.

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
