### PR TITLE
[MetaC]: Make Loadable in GToolkit

### DIFF
--- a/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/brickPackages..st
+++ b/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/brickPackages..st
@@ -3,5 +3,11 @@ brickPackages: spec
 	spec for: #'common' do: [
 		spec
 			package: #'Discord-UI-Brick' with: [ 
-				spec requires: #( #'Brick' #'Discord-Core' ) ]
+				spec requires: #( #'Discord-Core' ) ]
+	].
+	
+	spec for: #'notGToolkit' do: [
+		spec
+			package: #'Discord-UI-Brick' with: [ 
+				spec requires: #( #'Brick' ) ]
 	].

--- a/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/customProjectAttributes.st
+++ b/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/customProjectAttributes.st
@@ -1,0 +1,8 @@
+accessing
+customProjectAttributes
+
+	^ self isGTImage
+			ifTrue: [ #(GToolkit) ]
+			ifFalse: [ #(notGToolkit) ].
+			
+	"This is just for code generation purposes. To have an effect, it needs to be on the instance-side, but that could hide problems in other baselines because DeNigrisPreferences is not guaranteed to be loaded"

--- a/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/externalProjects..st
+++ b/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/externalProjects..st
@@ -4,19 +4,23 @@ externalProjects: spec
 		spec    
             baseline: 'Fuel' with: [ 
 				spec 
-					repository: 'github://theseion/Fuel:master/repository';
-					loads: 'CoreWithExtras' ];
+					repository: 'github://theseion/Fuel:master/repository' ];
 			baseline: 'NeoJSON' with: [
 				spec repository: 'github://svenvc/NeoJSON:master/repository' ];
-			baseline: 'Brick' with: [ 
-				spec
-					repository: 'github://pharo-graphics/Brick/src';
-					loads: #default ];
 			baseline: 'ExternalVolatileStore' with: [ 
 				spec
 					repository: 'github://feenkcom/external-volatile-store/src';
 					loads: #minimal ]
 	].
+	
+	spec for: #'notGToolkit' do: [
+		spec
+			baseline: 'Brick' with: [ 
+				spec
+					repository: 'github://pharo-graphics/Brick/src';
+					loads: #default ]
+	].
+	
 	spec for: #'pharo6.x' do: [
 		spec
 			configuration: 'ZincHTTPComponents' with: [ 

--- a/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/isGTImage.st
+++ b/src/BaselineOfDiscordSt.package/BaselineOfDiscordSt.class/instance/isGTImage.st
@@ -1,0 +1,5 @@
+testing
+isGTImage
+	
+	^ RPackageOrganizer default packageNames anySatisfy: [ :pn | pn beginsWith: 'Lepiter-' ].
+	"Implementation note: used to check for GToolkit prefix, but P7 has a GToolkit-Examples package. Lepiter, OTOH, could only be loaded in a GT image"


### PR DESCRIPTION
- More changes may be desired, but this fix gets it loading
- Updates to match current fuel, which no longer has CoreWithExtras group. Metalevel stuff now part of Core and progress stuff removed per https://github.com/theseion/Fuel/blob/4c500682853201c7388a451c9b032a296273feef/docs/releases/4.0.0.md